### PR TITLE
Build universal binary for macOS ARM64 and x86_64

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,10 +15,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - platform: 'macos-latest' # for Arm based macs (M1 and above).
-            args: '--target aarch64-apple-darwin'
-          - platform: 'macos-latest' # for Intel based macs.
-            args: '--target x86_64-apple-darwin'
+          - platform: 'macos-latest' # for universal (fat) binary for Mac (Apple Silicon and Intel)
+            args: '--target universal-apple-darwin'
           - platform: 'ubuntu-22.04' # for Tauri v1 you could replace this with ubuntu-20.04.
             args: ''
           - platform: 'windows-latest'

--- a/src-tauri/binaries/README.md
+++ b/src-tauri/binaries/README.md
@@ -1,0 +1,10 @@
+## Building macOS Universal Binary
+
+macOS supports universal binaries, which run natively on x86_64 and arm64. In order to build such a binary you need the two separate builds plus the `lipo` command line tool. Then run the following:
+
+```
+lipo -create \
+   -arch x86_64 squeezelite-x86_64-apple-darwin \
+   -arch arm64 squeezelite-aarch64-apple-darwin \
+   -output squeezelite-universal-apple-darwin
+```


### PR DESCRIPTION
`tauri` supports the `universal-apple-darwin` target which builds a binary compatible with both platforms. That way Mac users don't have to decide which binary to install.

```
% file src-tauri/target/universal-apple-darwin/release/lyrion-minim
src-tauri/target/universal-apple-darwin/release/lyrion-minim: Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit executable x86_64] [arm64]
src-tauri/target/universal-apple-darwin/release/lyrion-minim (for architecture x86_64): Mach-O 64-bit executable x86_64
src-tauri/target/universal-apple-darwin/release/lyrion-minim (for architecture arm64):  Mach-O 64-bit executable arm64
```

I can't test the automatic build on Github. But hopefully this will just work.